### PR TITLE
fix: Fix placeholder parsing order and prevent recursion in experience formulas  

### DIFF
--- a/src/main/kotlin/com/github/cpjinan/plugin/akarilevel/hook/PlaceholderAPIHook.kt
+++ b/src/main/kotlin/com/github/cpjinan/plugin/akarilevel/hook/PlaceholderAPIHook.kt
@@ -1,117 +1,196 @@
-package com.github.cpjinan.plugin.akarilevel.hook
-
-import com.github.cpjinan.plugin.akarilevel.level.LevelGroup
-import org.bukkit.OfflinePlayer
-import taboolib.common.platform.function.console
-import taboolib.common5.util.createBar
-import taboolib.module.chat.colored
-import taboolib.module.lang.asLangText
-import taboolib.platform.compat.PlaceholderExpansion
-
-/**
- * AkariLevel
- * com.github.cpjinan.plugin.akarilevel.hook
- *
- * PlaceholderAPI 挂钩。
- *
- * @author 季楠
- * @since 2025/8/17 20:07
- */
-object PlaceholderAPIHook : PlaceholderExpansion {
-    /**
-     * 变量前缀。
-     */
-    override val identifier = "akarilevel"
-
-    /**
-     * 离线玩家请求变量事件。
-     */
-    override fun onPlaceholderRequest(player: OfflinePlayer?, args: String): String {
-        val argsList = args.split("_")
-        val notAvailable = console().asLangText("PlaceholderNotAvailable")
-        if (player == null) return notAvailable
-        val playerName = player.name
-        val levelGroup = LevelGroup.getLevelGroups()[argsList[0]]
-        if (levelGroup == null) return notAvailable
-        val currentLevel = levelGroup.getMemberLevel(playerName)
-        val lastLevel = currentLevel - 1
-        val nextLevel = currentLevel + 1
-        val minLevel = levelGroup.getMinLevel()
-        val maxLevel = levelGroup.getMaxLevel()
-        val currentExp = levelGroup.getMemberExp(playerName)
-        val nextLevelExp = levelGroup.getLevelExp(playerName, currentLevel, nextLevel)
-
-        return when (argsList[1].lowercase()) {
-            // 等级组名称。
-            "name" -> levelGroup.name
-            "display" -> levelGroup.display.colored()
-
-            // 等级。
-            "level" -> currentLevel
-            "lastlevel" -> lastLevel
-            "nextlevel" -> nextLevel
-            "minlevel" -> minLevel
-            "maxlevel" -> maxLevel
-
-            // 经验。
-            "exp" -> currentExp
-
-            // 等级名称。
-            "levelname" -> levelGroup.getLevelName(playerName, currentLevel).colored()
-            "lastlevelname" -> levelGroup.getLevelName(playerName, lastLevel).colored()
-            "nextlevelname" -> levelGroup.getLevelName(playerName, nextLevel).colored()
-
-            // 升级所需经验。
-            "levelexp" -> levelGroup.getLevelExp(playerName, lastLevel, currentLevel)
-            "lastlevelexp" -> levelGroup.getLevelExp(playerName, currentLevel - 2, lastLevel)
-            "nextlevelexp" -> nextLevelExp
-
-            "levelexpfrom" -> {
-                val oldLevel = argsList[2].toLongOrNull() ?: return notAvailable
-                if (oldLevel > currentLevel) return notAvailable
-                levelGroup.getLevelExp(playerName, oldLevel, currentLevel)
-            }
-
-            "levelexpto" -> {
-                val newLevel = argsList[2].toLongOrNull() ?: return notAvailable
-                if (newLevel < currentLevel) return notAvailable
-                levelGroup.getLevelExp(playerName, currentLevel, newLevel)
-            }
-
-            "levelexpfromto" -> {
-                val oldLevel = argsList[2].toLongOrNull() ?: return notAvailable
-                val newLevel = argsList[3].toLongOrNull() ?: return notAvailable
-                if (oldLevel > newLevel) return notAvailable
-                levelGroup.getLevelExp(playerName, oldLevel, newLevel)
-            }
-
-            // 升级进度百分比。
-            "levelprogresspercent" -> {
-                (currentLevel.toDouble() / maxLevel * 100).coerceIn(0.0, 100.0).toLong()
-            }
-
-            "expprogresspercent" -> {
-                (currentExp.toDouble() / nextLevelExp * 100).coerceIn(0.0, 100.0).toLong()
-            }
-
-            // 升级进度条。
-            "levelprogressbar" -> {
-                createBar(
-                    argsList[2].colored(),
-                    argsList[3].colored(),
-                    argsList[4].toInt(),
-                    (currentLevel.toDouble() / maxLevel).coerceIn(0.0, 1.0)
-                )
-            }
-
-            "expprogressbar" -> createBar(
-                argsList[2].colored(),
-                argsList[3].colored(),
-                argsList[4].toInt(),
-                (currentExp.toDouble() / nextLevelExp).coerceIn(0.0, 1.0)
-            )
-
-            else -> notAvailable
-        }.toString()
-    }
+package com.github.cpjinan.plugin.akarilevel.hook  
+  
+import com.github.cpjinan.plugin.akarilevel.level.LevelGroup  
+import org.bukkit.OfflinePlayer  
+import taboolib.common.platform.function.console  
+import taboolib.common5.util.createBar  
+import taboolib.module.chat.colored  
+import taboolib.module.lang.asLangText  
+import taboolib.platform.compat.PlaceholderExpansion  
+  
+/**  
+ * AkariLevel  
+ * com.github.cpjinan.plugin.akarilevel.hook  
+ *  
+ * PlaceholderAPI 挂钩。  
+ *  
+ * @author 季楠  
+ * @since 2025/8/17 20:07  
+ */  
+object PlaceholderAPIHook : PlaceholderExpansion {  
+    /**  
+     * 变量前缀。  
+     */  
+    override val identifier = "akarilevel"  
+      
+    /**  
+     * 用于检测递归的 ThreadLocal 标志。  
+     */  
+    private val isCalculating = ThreadLocal.withInitial { false }  
+  
+    /**  
+     * 离线玩家请求变量事件。  
+     */  
+    override fun onPlaceholderRequest(player: OfflinePlayer?, args: String): String {  
+        val argsList = args.split("_")  
+        val notAvailable = console().asLangText("PlaceholderNotAvailable")  
+        if (player == null) return notAvailable  
+          
+        val playerName = player.name  
+        val levelGroup = LevelGroup.getLevelGroups()[argsList[0]]  
+        if (levelGroup == null) return notAvailable  
+          
+        // 检测是否已在计算中以防止递归
+        if (isCalculating.get()) {  
+            val currentLevel = levelGroup.getMemberLevel(playerName)  
+            return when (argsList[1].lowercase()) {  
+                // 等级组名称。  
+                "name" -> levelGroup.name  
+                "display" -> levelGroup.display.colored()  
+                  
+                // 等级。  
+                "level" -> currentLevel  
+                "lastlevel" -> currentLevel - 1  
+                "nextlevel" -> currentLevel + 1  
+                "minlevel" -> levelGroup.getMinLevel()  
+                "maxlevel" -> levelGroup.getMaxLevel()  
+                  
+                // 经验。  
+                "exp" -> levelGroup.getMemberExp(playerName)  
+                  
+                // 等级名称。  
+                "levelname" -> levelGroup.getLevelName(currentLevel).colored()  
+                "lastlevelname" -> levelGroup.getLevelName(currentLevel - 1).colored()  
+                "nextlevelname" -> levelGroup.getLevelName(currentLevel + 1).colored()  
+                  
+                // 升级所需经验。  
+                "levelexp" -> levelGroup.getLevelExp(currentLevel - 1, currentLevel)  
+                "lastlevelexp" -> levelGroup.getLevelExp(currentLevel - 2, currentLevel - 1)  
+                "nextlevelexp" -> levelGroup.getLevelExp(currentLevel, currentLevel + 1)  
+                  
+                "levelexpfrom" -> {  
+                    val oldLevel = argsList[2].toLongOrNull() ?: return notAvailable  
+                    if (oldLevel > currentLevel) return notAvailable  
+                    levelGroup.getLevelExp(oldLevel, currentLevel)  
+                }  
+                  
+                "levelexpto" -> {  
+                    val newLevel = argsList[2].toLongOrNull() ?: return notAvailable  
+                    if (newLevel < currentLevel) return notAvailable  
+                    levelGroup.getLevelExp(currentLevel, newLevel)  
+                }  
+                  
+                "levelexpfromto" -> {  
+                    val oldLevel = argsList[2].toLongOrNull() ?: return notAvailable  
+                    val newLevel = argsList[3].toLongOrNull() ?: return notAvailable  
+                    if (oldLevel > newLevel) return notAvailable  
+                    levelGroup.getLevelExp(oldLevel, newLevel)  
+                }  
+                  
+                // 升级进度百分比。  
+                "levelprogresspercent" -> {  
+                    (currentLevel.toDouble() / levelGroup.getMaxLevel() * 100).coerceIn(0.0, 100.0).toLong()  
+                }  
+                  
+                "expprogresspercent" -> {  
+                    val currentExp = levelGroup.getMemberExp(playerName)  
+                    val nextLevelExp = levelGroup.getLevelExp(currentLevel, currentLevel + 1)  
+                    (currentExp.toDouble() / nextLevelExp * 100).coerceIn(0.0, 100.0).toLong()  
+                }  
+                  
+                // 升级进度条。  
+                "levelprogressbar", "expprogressbar" -> ""  
+                  
+                else -> notAvailable  
+            }.toString()  
+        }  
+          
+        // 标记正在计算中  
+        isCalculating.set(true)  
+        try {  
+            val currentLevel = levelGroup.getMemberLevel(playerName)  
+            val lastLevel = currentLevel - 1  
+            val nextLevel = currentLevel + 1  
+            val minLevel = levelGroup.getMinLevel()  
+            val maxLevel = levelGroup.getMaxLevel()  
+            val currentExp = levelGroup.getMemberExp(playerName)  
+            val nextLevelExp = levelGroup.getLevelExp(playerName, currentLevel, nextLevel)  
+  
+            return when (argsList[1].lowercase()) {  
+                // 等级组名称。  
+                "name" -> levelGroup.name  
+                "display" -> levelGroup.display.colored()  
+  
+                // 等级。  
+                "level" -> currentLevel  
+                "lastlevel" -> lastLevel  
+                "nextlevel" -> nextLevel  
+                "minlevel" -> minLevel  
+                "maxlevel" -> maxLevel  
+  
+                // 经验。  
+                "exp" -> currentExp  
+  
+                // 等级名称。  
+                "levelname" -> levelGroup.getLevelName(playerName, currentLevel).colored()  
+                "lastlevelname" -> levelGroup.getLevelName(playerName, lastLevel).colored()  
+                "nextlevelname" -> levelGroup.getLevelName(playerName, nextLevel).colored()  
+  
+                // 升级所需经验。  
+                "levelexp" -> levelGroup.getLevelExp(playerName, lastLevel, currentLevel)  
+                "lastlevelexp" -> levelGroup.getLevelExp(playerName, currentLevel - 2, lastLevel)  
+                "nextlevelexp" -> nextLevelExp  
+  
+                "levelexpfrom" -> {  
+                    val oldLevel = argsList[2].toLongOrNull() ?: return notAvailable  
+                    if (oldLevel > currentLevel) return notAvailable  
+                    levelGroup.getLevelExp(playerName, oldLevel, currentLevel)  
+                }  
+  
+                "levelexpto" -> {  
+                    val newLevel = argsList[2].toLongOrNull() ?: return notAvailable  
+                    if (newLevel < currentLevel) return notAvailable  
+                    levelGroup.getLevelExp(playerName, currentLevel, newLevel)  
+                }  
+  
+                "levelexpfromto" -> {  
+                    val oldLevel = argsList[2].toLongOrNull() ?: return notAvailable  
+                    val newLevel = argsList[3].toLongOrNull() ?: return notAvailable  
+                    if (oldLevel > newLevel) return notAvailable  
+                    levelGroup.getLevelExp(playerName, oldLevel, newLevel)  
+                }  
+  
+                // 升级进度百分比。  
+                "levelprogresspercent" -> {  
+                    (currentLevel.toDouble() / maxLevel * 100).coerceIn(0.0, 100.0).toLong()  
+                }  
+  
+                "expprogresspercent" -> {  
+                    (currentExp.toDouble() / nextLevelExp * 100).coerceIn(0.0, 100.0).toLong()  
+                }  
+  
+                // 升级进度条。  
+                "levelprogressbar" -> {  
+                    createBar(  
+                        argsList[2].colored(),  
+                        argsList[3].colored(),  
+                        argsList[4].toInt(),  
+                        (currentLevel.toDouble() / maxLevel).coerceIn(0.0, 1.0)  
+                    )  
+                }  
+  
+                "expprogressbar" -> createBar(  
+                    argsList[2].colored(),  
+                    argsList[3].colored(),  
+                    argsList[4].toInt(),  
+                    (currentExp.toDouble() / nextLevelExp).coerceIn(0.0, 1.0)  
+                )  
+  
+                else -> notAvailable  
+            }.toString()  
+        } finally {  
+            // 始终清理标志  
+            isCalculating.set(false)  
+        }  
+    }  
 }

--- a/src/main/kotlin/com/github/cpjinan/plugin/akarilevel/level/ConfigLevelGroup.kt
+++ b/src/main/kotlin/com/github/cpjinan/plugin/akarilevel/level/ConfigLevelGroup.kt
@@ -90,12 +90,15 @@ class ConfigLevelGroup(val config: ConfigurationSection) : LevelGroup {
         return getLevelConfig(level).getString("Name")?.replace("{level}" to level)?.colored() ?: "$level"
     }
 
-    override fun getLevelName(member: String, level: Long): String {
-        return getLevelName(level).let {
-            val offlinePlayer = getOfflinePlayer(member)
-            if (offlinePlayer.hasPlayedBefore()) it.replacePlaceholder(offlinePlayer)
-            else it
-        }
+    override fun getLevelName(member: String, level: Long): String {  
+        return getLevelConfig(level).getString("Name")  
+            ?.let {  
+                val offlinePlayer = getOfflinePlayer(member)  
+                if (offlinePlayer.hasPlayedBefore()) it.replacePlaceholder(offlinePlayer)  
+                else it  
+            }  
+            ?.replace("{level}" to level)
+            ?.colored() ?: "$level"  
     }
 
     override fun getLevelExp(oldLevel: Long, newLevel: Long): Long {
@@ -120,12 +123,12 @@ class ConfigLevelGroup(val config: ConfigurationSection) : LevelGroup {
         return (oldLevel + 1..newLevel).sumOf {
             Arim.fixedCalculator.evaluate(
                 getLevelConfig(it).getString("Exp").orEmpty()
-                    .replace("{level}" to it)
                     .let {
                         val offlinePlayer = getOfflinePlayer(member)
                         if (offlinePlayer.hasPlayedBefore()) it.replacePlaceholder(offlinePlayer)
                         else it
                     }
+                    .replace("{level}" to it)
             ).toLong()
         }
     }


### PR DESCRIPTION
## Problem  
  
Users reported two issues when using placeholders in experience formulas:  
  
1. **External placeholders with `{level}` not working**: When using placeholders from other plugins (e.g., `%imc_exp-lvl-formula_1%`) that return formulas containing `{level}`, the `{level}` variable inside the placeholder's value was not being replaced, causing calculation errors.  
  
2. **Infinite recursion with AkariLevel placeholders**: Using AkariLevel's own placeholders (e.g., `%akarilevel_network_level%`) in `Exp` formulas caused `NoSuchElementException` and stack overflow errors due to circular dependencies.  
  
## Solution  
  
### ConfigLevelGroup.kt Changes  
  
Inverted the processing order in `getLevelExp(member, oldLevel, newLevel)` and `getLevelName(member, level)`:  
- **Before**: Replace `{level}` → Parse PlaceholderAPI placeholders  
- **After**: Parse PlaceholderAPI placeholders → Replace `{level}`  
  
This ensures that any `{level}` tokens inside placeholder values get processed correctly.  
  
### PlaceholderAPIHook.kt Changes  
  
Added recursion detection using `ThreadLocal<Boolean>`:  
- When a placeholder request is already being processed, subsequent recursive calls return simple values without triggering additional placeholder parsing  
- Wrapped main logic in `try-finally` block to ensure the recursion flag is always cleaned up, even if exceptions occur  
- Added fallback handling for all placeholder types that could cause recursion (`level`, `nextlevel`, `levelexp`, `nextlevelexp`, etc.)  
  
## Testing  
  
Tested with:  
- External placeholder `%imc_exp-lvl-formula_1%` returning `({level}^2) * 2500 + 10000` ✓  
- AkariLevel placeholder `%akarilevel_network_level%` in Exp formula ✓  
- Mixed formulas with both `{level}` and placeholders ✓  
  
## Breaking Changes  
  
None. This is a bug fix that makes the system work as originally intended.  
  
## Notes  
  
While this fix allows AkariLevel placeholders to be used in `Exp` formulas without crashing, it's still not recommended because they return constant values (current level) instead of iteration variables. The `{level}` variable remains the correct way to define level-based progression formulas.